### PR TITLE
BUGFIX: Middleware never intercepted request

### DIFF
--- a/Classes/Http/GraphQLUploadMiddleware.php
+++ b/Classes/Http/GraphQLUploadMiddleware.php
@@ -56,7 +56,7 @@ class GraphQLUploadMiddleware implements MiddlewareInterface
 
     protected function isGraphQLRequest(ServerRequestInterface $request): bool
     {
-        $routingMatchResults = $request->getAttribute('matchResults') ?? [];
+        $routingMatchResults = $request->getAttribute('routingResults') ?? [];
         $package = $routingMatchResults['@package'] ?? null;
         $controller = $routingMatchResults['@controller'] ?? null;
         $action = $routingMatchResults['@action'] ?? null;


### PR DESCRIPTION
Since Flow 7 the routing result is in the attribute `routingResults`.